### PR TITLE
Fix connected component labels

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -21,6 +21,13 @@ API Reference
 
     TiledPartition
 
+**Connected Component Labeling**
+
+.. autosummary::
+    :toctree: api
+
+    DisjointSetForest
+
 **Signal Processing**
 
 .. autosummary::

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -27,6 +27,8 @@ API Reference
     :toctree: api
 
     DisjointSetForest
+    deduplicate_labels
+    merge_equivalent_labels
 
 **Signal Processing**
 

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -17,6 +17,22 @@
  source = {Crossref},
 }
 
+@article{fiorio:1996,
+ author = {Fiorio, Christophe and Gustedt, Jens},
+ title = {Two linear time Union-Find strategies for image processing},
+ journal = {Theoretical Computer Science},
+ year = {1996},
+ month = feb,
+ publisher = {Elsevier BV},
+ volume = {154},
+ number = {2},
+ pages = {165--181},
+ url = {https://doi.org/10.1016/0304-3975(94)00262-2},
+ doi = {10.1016/0304-3975(94)00262-2},
+ issn = {0304-3975},
+ source = {Crossref},
+}
+
 @inproceedings{kaiser:1974,
  author = {Kaiser, James F.},
  title = {Nonrecursive Digital Filter Design Using the I0-Sinh Window Function.},

--- a/src/tophu/__init__.py
+++ b/src/tophu/__init__.py
@@ -1,4 +1,5 @@
 from .filter import *
+from .label import *
 from .multilook import *
 from .multiscale import *
 from .tile import *

--- a/src/tophu/__init__.py
+++ b/src/tophu/__init__.py
@@ -2,6 +2,7 @@ from .filter import *
 from .multilook import *
 from .multiscale import *
 from .tile import *
+from .union_find import *
 from .unwrap import *
 from .upsample import *
 

--- a/src/tophu/label.py
+++ b/src/tophu/label.py
@@ -133,8 +133,8 @@ def find_connected_labels(
     Find equivalent labels based on pixel connectivity.
 
     Determine the set of equivalent labels to the specified label. Two nonzero labels
-    are considered equivalent if the `conncomp` array contains any two connected pixels
-    with those respective labels.
+    are considered equivalent if there is any connected path between pixels with these
+    labels.
 
     Zero-valued pixels are ignored.
 

--- a/src/tophu/label.py
+++ b/src/tophu/label.py
@@ -1,0 +1,287 @@
+import itertools
+from typing import Set, Tuple
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+from scipy import ndimage
+
+from .tile import TiledPartition
+from .union_find import DisjointSetForest
+
+__all__ = [
+    "deduplicate_labels",
+    "merge_equivalent_labels",
+    "unique_nonzero_integers",
+]
+
+
+NDSlice = Tuple[slice, ...]
+
+
+def deduplicate_labels(
+    conncomp: NDArray[np.unsignedinteger],
+    tiles: TiledPartition,
+) -> None:
+    """
+    De-duplicate connected component labels from different tiles.
+
+    Connected component labels within each tile are updated such that no tile has any
+    label in common with any other tile.
+
+    Only nonzero labels are modified. Zero-valued pixels are treated as masked out (i.e.
+    not part of any connected component).
+
+    The `conncomp` array is modified in-place.
+
+    Parameters
+    ----------
+    conncomp : numpy.ndarray
+        The input connected component labels.
+    tiles : TiledPartition
+        A set of tiles that spans the `conncomp` array. Each tile is represented by an
+        index expression (i.e. a tuple of `slice` objects) that can be used to access
+        a corresponding block of data from the partitioned array.
+
+    See Also
+    --------
+    merge_equivalent_labels
+    """
+    # Keep track of the largest connected component label encountered while looping over
+    # tiles.
+    max_label = 0
+    for tile in tiles:
+        # Get a mask of elements within the tile with nonzero connected component
+        # labels.
+        mask = conncomp[tile] != 0
+
+        # Update connected component labels by adding the largest label value from among
+        # all previously encountered tiles. Zero-valued labels are not changed. The
+        # input connected component labels array is modified in-place.
+        conncomp[tile][mask] += max_label
+
+        # Get the new maximum connected component label.
+        max_label = max(max_label, np.max(conncomp[tile]))
+
+
+def expand_tile(tile: NDSlice, margin: int) -> NDSlice:
+    """
+    Expand a tile by adding some margin to each border.
+
+    Parameters
+    ----------
+    tile : tuple of slice
+        A tuple of slice objects representing a multi-dimensional indexing expression,
+        such as that returned by `numpy.index_exp`.
+    margin : int
+        The number of samples to add to each border of the tile.
+
+    Returns
+    -------
+    expanded_tile : tuple of slice
+        The expanded indexing expression.
+    """
+    if margin < 0:
+        raise ValueError("margin must be >= 0")
+
+    def expand_slice(s: slice) -> slice:
+        if s.start is None:
+            new_start = None
+        else:
+            # Subtract `margin` from the start index of the slice. We need to be careful
+            # to avoid changing the sign of the index since negative indices in Python
+            # typically wrap around.
+            sign_change = (s.start >= 0) and (s.start < margin)
+            new_start = 0 if sign_change else s.start - margin
+
+        if s.stop is None:
+            new_stop = None
+        else:
+            # Add `margin` to the stop index of the slice. Avoid changing the sign of
+            # the index.
+            sign_change = (s.stop < 0) and (s.stop >= -margin)
+            new_stop = None if sign_change else s.stop + margin
+
+        return slice(new_start, new_stop, s.step)
+
+    return tuple([expand_slice(s) for s in tile])
+
+
+def unique_nonzero_integers(x: ArrayLike, /) -> Set:
+    """
+    Find unique nonzero elements in the input array.
+
+    Parameters
+    ----------
+    x : array_like
+        An array of integers.
+
+    Returns
+    -------
+    s : set
+        The set of unique nonzero values.
+    """
+    return set(np.unique(x)) - {0}
+
+
+def find_connected_labels(
+    label: int,
+    conncomp: NDArray[np.unsignedinteger],
+    *,
+    connectivity: int = 1,
+) -> Set[int]:
+    """
+    Find equivalent labels based on pixel connectivity.
+
+    Determine the set of equivalent labels to the specified label. Two nonzero labels
+    are considered equivalent if the `conncomp` array contains any two connected pixels
+    with those respective labels.
+
+    Zero-valued pixels are ignored.
+
+    Parameters
+    ----------
+    label : int
+        The query label.
+    conncomp : numpy.ndarray
+        A two-dimensional array of positive integer labels associated with connected
+        components. Some connected components may have more than one label. Zero-valued
+        pixels are treated as masked-out (i.e. not part of any connected component).
+    connectivity : int, optional
+        Determines which pixels are considered connected. Valid values are 1 or 2. If
+        `connectivity=1`, only a pixel's 4 orthogonal neighbors are considered
+        connected. If `connectivity=2`, a pixel's 8 orthogonal and diagonal neighbors
+        are considered connected. (default: 1)
+
+    Returns
+    -------
+    equivalent_labels : set of int
+        A set of connected component labels that are equivalent to the specified label.
+    """
+    if connectivity not in {1, 2}:
+        raise ValueError("connectivity must be 1 or 2")
+
+    # Get a mask of pixels in `conncomp` with value equal to `label`.
+    mask = conncomp == label
+
+    # Dilate the masked region to include bordering pixels.
+    struct = ndimage.generate_binary_structure(conncomp.ndim, connectivity)
+    dilated_mask = ndimage.binary_dilation(mask, struct)
+
+    # Get a mask of only pixels bordering the labeled region.
+    edge_mask = dilated_mask ^ mask
+
+    # Get the set of unique nonzero values in the bordering pixels.
+    return unique_nonzero_integers(conncomp[edge_mask])
+
+
+def merge_equivalent_labels(
+    conncomp: NDArray[np.unsignedinteger],
+    tiles: TiledPartition,
+    *,
+    connectivity: int = 1,
+) -> NDArray[np.unsignedinteger]:
+    r"""
+    Merge equivalent connected component labels.
+
+    Find connected components in the input array with multiple labels and relabel them
+    with a single unique label. After relabeling, each individual connected region is
+    assigned a new positive integer label in [1, 2, ..., N], where N is the total number
+    of disjoint connected components.
+
+    Zero-valued pixels are treated as masked out (i.e. not part of any connected
+    component). They are not relabeled.
+
+    A two-pass algorithm is used to determine the new connected components\
+    :footcite:p:`fiorio:1996`. In the first phase, the initial labels are scanned and
+    label equivalence information is stored in
+    a `Union-Find data structure
+    <https://en.wikipedia.org/wiki/Disjoint-set_data_structure>`_. Each set of
+    equivalent labels is associated with a unique final label. A second pass through the
+    data assigns each pixel its final label.
+
+    Parameters
+    ----------
+    conncomp : numpy.ndarray
+        The initial connected component labels. A two-dimensional array of nonnegative
+        integer values. Some connected components may have more than one label.
+        Zero-valued pixels are treated as masked-out (i.e. not part of any connected
+        component).
+    tiles : TiledPartition
+        A set of tiles that spans the `conncomp` array. Each tile is represented by an
+        index expression (i.e. a tuple of `slice` objects) that can be used to access
+        a corresponding block of data from the partitioned array.
+    connectivity : int, optional
+        Determines which pixels are considered connected. Valid values are 1 or 2. If
+        `connectivity=1`, only a pixel's 4 orthogonal neighbors are considered
+        connected. If `connectivity=2`, a pixel's 8 orthogonal and diagonal neighbors
+        are considered connected. (default: 1)
+
+    Returns
+    -------
+    new_conncomp : numpy.ndarray
+        The output array of updated connected component labels.
+
+    See Also
+    --------
+    deduplicate_labels
+    """
+    # Initialize the union-find data structure.
+    forest: DisjointSetForest[int] = DisjointSetForest()
+
+    # First pass: compute label equivalences.
+    for tile in tiles:
+        # Expand the tile by one pixel along each border so that it overlaps with
+        # neighboring tiles.
+        expanded_tile = expand_tile(tile, 1)
+
+        # Find unique nonzero labels and add them as new disjoint sets to the union-find
+        # data structure.
+        unique_nonzero_labels = unique_nonzero_integers(conncomp[expanded_tile])
+        forest.add_items(unique_nonzero_labels)
+
+        # Loop over the set of labels.
+        for label in unique_nonzero_labels:
+            # Find any equivalent labels (i.e. labels associated with any neighboring
+            # connected pixel).
+            equivalent_labels = find_connected_labels(
+                label,
+                conncomp[expanded_tile],
+                connectivity=connectivity,
+            )
+
+            # Merge equivalent labels.
+            for equivalent_label in equivalent_labels:
+                forest.union(label, equivalent_label)
+
+    # Flatten the forest so that each node in each tree is a direct child of its root
+    # node in order to improve efficiency of tree traversal.
+    forest.flatten()
+
+    # After the first pass, each disjoint set of equivalent labels is now associated
+    # with a new unique label (represented by the root of each tree within the
+    # disjoint-set forest). However, these new labels are not necessarily consecutive
+    # integers, nor are they necessarily bounded by the total number of connected
+    # components.
+
+    # Define a mapping from the set of representative labels (root nodes) in the
+    # disjoint-set forest to the sequence of natural numbers 1 through N (where N is the
+    # total number of disjoint sets), which will form the final set of labels.
+    final_labels = dict(zip(forest.roots(), itertools.count(1)))
+
+    # Init output connected component labels array.
+    new_conncomp = np.zeros_like(conncomp)
+
+    # Second pass: relabel connected components.
+    for tile in tiles:
+        # Get the set of unique nonzero labels within the tile.
+        unique_nonzero_labels = unique_nonzero_integers(conncomp[tile])
+
+        for label in unique_nonzero_labels:
+            # Get a mask of pixels in the tile with value equal to `label`.
+            mask = conncomp[tile] == label
+
+            # Relabel pixels with their new assigned label.
+            root = forest.find(label)
+            new_conncomp[tile][mask] = final_labels[root]
+
+    return new_conncomp

--- a/src/tophu/multiscale.py
+++ b/src/tophu/multiscale.py
@@ -6,6 +6,7 @@ import scipy.signal
 from numpy.typing import ArrayLike, NDArray
 
 from .filter import bandpass_equiripple_filter
+from .label import deduplicate_labels, merge_equivalent_labels
 from .multilook import multilook
 from .tile import TiledPartition
 from .unwrap import UnwrapCallback
@@ -497,4 +498,11 @@ def multiscale_unwrap(
             conncomp_lores[tile],
         )
 
-    return unwrapped_phase, conncomp
+    # De-duplicate connected component labels from different tiles.
+    deduplicate_labels(conncomp, tiles)
+
+    # Merge equivalent connected component labels such that components that span
+    # multiple tiles are associated with a single unique label.
+    new_conncomp = merge_equivalent_labels(conncomp, tiles)
+
+    return unwrapped_phase, new_conncomp

--- a/src/tophu/union_find.py
+++ b/src/tophu/union_find.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from collections.abc import Hashable, Iterable
+from typing import Any, Dict, Generic, Set, TypeVar
+
+__all__ = [
+    "DisjointSetForest",
+]
+
+
+T = TypeVar("T", bound=Hashable)
+
+
+class DisjointSetForest(Generic[T]):
+    """
+    A Union-Find data structure.
+
+    `DisjointSetForest` stores a set of items that are partitioned into disjoint
+    subsets. Each subset is identified by a unique representative exemplar chosen from
+    among items within the subset. The data structure supports operations for adding
+    items to the set, merging two subsets, and finding set representatives.
+
+    Conceptually, a `DisjointSetForest` is represented by a forest of `parent pointer
+    trees <https://en.wikipedia.org/wiki/Parent_pointer_tree>`_, with each node in the
+    forest corresponding to an item in the set, and each tree corresponding to a
+    disjoint subset of the full set. Nodes are linked to their parent node within the
+    same tree (except for root nodes, which are linked to themselves or a sentinel
+    node). The root node of each tree acts as the unique representative for that subset.
+
+    `DisjointSetForest` can only be used with hashable objects.
+    """
+
+    def __init__(self, items: Iterable[T] = ()):
+        """
+        Construct a new `DisjointSetForest` object.
+
+        Initially, each item in the set is treated as a disjoint singleton subset
+        (represented by a tree containing a single node).
+
+        Parameters
+        ----------
+        items : iterable
+            Items within the set.
+        """
+        # Internally, the forest is stored as an associative container which maps each
+        # node to its parent node. Root nodes are mapped to themselves.
+        self._parents: Dict[T, T] = {}
+
+        # Add nodes to the forest.
+        self.add_items(items)
+
+    def __contains__(self, item: T) -> bool:
+        return self.contains(item)
+
+    def __iter__(self) -> Iterable[T]:
+        return self.items()
+
+    def __len__(self) -> int:
+        return self.num_items()
+
+    def __eq__(self, other: Any) -> bool:
+        return (type(self) == type(other)) and (self._parents == other._parents)
+
+    def copy(self) -> DisjointSetForest[T]:
+        """
+        Create a shallow copy of the `DisjointSetForest` object.
+
+        Returns
+        -------
+        copy : DisjointSetForest
+            A copy of the disjoint-set forest.
+        """
+        other: DisjointSetForest[T] = DisjointSetForest()
+        other._parents = self._parents.copy()
+        return other
+
+    def contains(self, item: T) -> bool:
+        """
+        Check whether an item is a member of the set.
+
+        Parameters
+        ----------
+        item : object
+            The item to check for.
+
+        Returns
+        -------
+        found : bool
+            True if a node in the forest contained `item`, otherwise False.
+        """
+        return item in self._parents
+
+    def add_item(self, item: T) -> None:
+        """
+        Add an item to the set.
+
+        This has no effect if the item is already a member of the set. Otherwise, it
+        creates a new disjoint subset containing a single item.
+
+        Parameters
+        ----------
+        item : object
+            The new item to add.
+        """
+        # Do nothing if the item is already found in the forest.
+        if self.contains(item):
+            return
+
+        # Otherwise, add the item as a new root node.
+        self._parents[item] = item
+
+    def add_items(self, items: Iterable[T]) -> None:
+        """
+        Add items to the set.
+
+        Each item is added to the forest as a disjoint singleton subset (represented by
+        a tree containing a single node).
+
+        Adding an item that is already a member of set has no effect.
+
+        Parameters
+        ----------
+        items : iterable
+            The new items to add.
+        """
+        for item in items:
+            self.add_item(item)
+
+    def items(self) -> Iterable[T]:
+        """
+        Iterate over items within the set.
+
+        Each item is visited in the order in which it was added to the set.
+
+        Yields
+        ------
+        item : object
+            An item within the set.
+        """
+        yield from self._parents.keys()
+
+    def roots(self) -> Set[T]:
+        """
+        Get subset representatives.
+
+        Find the root node of each tree in the forest. Each rooted tree in the forest
+        corresponds to a disjoint subset of the total set of items. The root node is
+        treated as a representative exemplar of the corresponding subset.
+
+        Returns
+        -------
+        roots : set
+            The set of root nodes of each tree in the forest.
+        """
+        return {self.find(item) for item in self.items()}
+
+    def num_items(self) -> int:
+        """
+        Get the number of items in the set.
+
+        Returns
+        -------
+        n : int
+            The total number of nodes in the forest.
+        """
+        return len(self._parents)
+
+    def num_trees(self) -> int:
+        """
+        Get the number of disjoint subsets in the set.
+
+        Returns
+        -------
+        n : int
+            The number of trees in the forest.
+        """
+        return len(self.roots())
+
+    def get_parent(self, item: T) -> T:
+        """
+        Get the parent of the specified item.
+
+        Parameters
+        ----------
+        item : object
+            An item within the set.
+
+        Returns
+        -------
+        parent : object
+            The item occupying the parent node within the same tree.
+
+        Raises
+        ------
+        ValueError
+            If `item` is not found in the forest.
+
+        Notes
+        -----
+        A root node's parent is itself.
+        """
+        try:
+            return self._parents[item]
+        except KeyError:
+            raise ValueError(f"item not found: {item}")
+
+    def set_parent(self, item: T, parent: T) -> None:
+        """
+        Set the parent of the specified item.
+
+        Both the child and parent must already be set members.
+
+        Parameters
+        ----------
+        item : object
+            The child item.
+        parent : object
+            The new parent item.
+
+        Raises
+        ------
+        ValueError
+            If either `item` or `parent` is not found in the forest.
+        """
+        if item not in self._parents:
+            raise ValueError(f"item not found: {item}")
+        if parent not in self._parents:
+            raise ValueError(f"item not found: {parent}")
+
+        self._parents[item] = parent
+
+    def iter_parents(self, item: T) -> Iterable[T]:
+        """
+        Iterate over ancestors of a specified node.
+
+        Parameters
+        ----------
+        item : object
+            An item within the forest.
+
+        Yields
+        ------
+        parent : object
+            An ancestor of the specified item.
+        """
+        child, parent = item, self.get_parent(item)
+        while parent != child:
+            yield parent
+            child, parent = parent, self.get_parent(parent)
+
+    def find(self, item: T) -> T:
+        """
+        Find the representative item of a subset.
+
+        Parameters
+        ----------
+        item : object
+            Provisional label.
+
+        Returns
+        -------
+        root : object
+            Representative for the set that contains `item`.
+
+        Notes
+        -----
+        The subset representative is the root of the tree that contains `item`.
+        """
+        child, parent = item, self.get_parent(item)
+        while parent != child:
+            child, parent = parent, self.get_parent(parent)
+        return parent
+
+    def union(self, x: T, y: T, /) -> None:
+        """
+        Merge two subsets.
+
+        Has no effect if the two items are already members of the same subset.
+
+        Parameters
+        ----------
+        x, y : object
+            Items to merge.
+        """
+        # Get the root of each node's tree.
+        xroot = self.find(x)
+        yroot = self.find(y)
+
+        # If `x` and `y` are already members of the same tree, do nothing.
+        if xroot == yroot:
+            return
+
+        # Merge the two trees.
+        self.set_parent(xroot, yroot)
+
+    def flatten(self) -> None:
+        """
+        Flatten the forest.
+
+        Modify the forest's topology so that each node is a direct child of its root
+        node.
+        """
+        for item in self.items():
+            root = self.find(item)
+            self.set_parent(item, root)
+
+    def is_disjoint(self, x: T, y: T, /) -> bool:
+        """
+        Check whether two members of the set belong to disjoint subsets.
+
+        Parameters
+        ----------
+        x, y : object
+            Items within the set.
+
+        Returns
+        -------
+        b : bool
+            True if `x` and `y` belong to different trees, otherwise False.
+        """
+        xroot = self.find(x)
+        yroot = self.find(y)
+        return xroot != yroot

--- a/src/tophu/union_find.py
+++ b/src/tophu/union_find.py
@@ -255,7 +255,7 @@ class DisjointSetForest(Generic[T]):
         Parameters
         ----------
         item : object
-            Provisional label.
+            An item within the set.
 
         Returns
         -------

--- a/test/test_label.py
+++ b/test/test_label.py
@@ -1,0 +1,258 @@
+import itertools
+from typing import Optional, Tuple
+
+import numpy as np
+import pytest
+import scipy.ndimage
+from numpy.typing import NDArray
+
+import tophu
+
+
+def random_binary_mask(
+    shape: Tuple[int, ...],
+    *,
+    density: float,
+    seed: Optional[int] = None,
+) -> NDArray[np.bool_]:
+    """
+    Create a random binary mask.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        The shape of the output array.
+    density : float
+        The approximate density of nonzero values in the mask. Must be between 0 and 1.
+    seed : int or None, optional
+        Seed for initializing pseudo-random number generator state. Must be nonnegative.
+        If None, then the generator will be initialized randomly. (default: None)
+
+    Returns
+    -------
+    mask : numpy.ndarray
+        A randomly generated binary mask.
+    """
+    if (density < 0.0) or (density > 1.0):
+        raise ValueError("density must be >= 0 and <= 1")
+
+    # Setup a pseudo-random number generator.
+    rng = np.random.default_rng(seed)
+
+    # Generate a random binary mask by uniformly sampling the interval [0, 1] and
+    # thresholding.
+    return rng.uniform(size=shape) < density
+
+
+def random_conncomp_labels(
+    shape: Tuple[int, ...],
+    *,
+    density: float,
+    seed: Optional[int] = None,
+) -> NDArray[np.integer]:
+    """
+    Create a random array of connected component labels.
+
+    Each connected component is assigned a unique positive integer label. Pixels not
+    belonging to any connected component are labeled 0.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        The shape of the output array.
+    density : float
+        The approximate density of nonzero values in the output array. Must be between 0
+        and 1.
+    seed : int or None, optional
+        Seed for initializing pseudo-random number generator state. Must be nonnegative.
+        If None, then the generator will be initialized randomly. (default: None)
+
+    Returns
+    -------
+    conncomp : numpy.ndarray
+        The output array of randomly generated connected component labels.
+    """
+    mask = random_binary_mask(shape, density=density, seed=seed)
+    conncomp, _ = scipy.ndimage.label(mask)
+    return conncomp
+
+
+class TestDeduplicateLabels:
+    def test1(self):
+        # Initially, each pixel belongs to a single connected component with label 1.
+        shape = (1024, 1024)
+        conncomp = np.ones(shape, dtype=np.uint32)
+
+        # De-duplicate labels from different tiles.
+        tiles = tophu.TiledPartition(shape, ntiles=(3, 3))
+        tophu.deduplicate_labels(conncomp, tiles)
+
+        # After re-labeling, there should be no common labels between different tiles.
+        # Get the set of unique labels within each tile and check that each pair of sets
+        # is disjoint (has no common elements).
+        tile_label_sets = [set(np.unique(conncomp[tile])) for tile in tiles]
+        for set1, set2 in itertools.combinations(tile_label_sets, r=2):
+            assert set1.isdisjoint(set2)
+
+    def test2(self):
+        length, width = 512, 512
+
+        # Create two connected components: one outer rectangular annulus and one inner
+        # rectangle.
+        conncomp1_mask = np.ones((length, width), dtype=np.bool_)
+        conncomp1_mask[64:-64, 64:-64] = False
+
+        conncomp2_mask = np.zeros((length, width), dtype=np.bool_)
+        conncomp2_mask[192:-192, 192:-192] = True
+
+        conncomp = np.zeros((length, width), dtype=np.uint32)
+        conncomp[conncomp1_mask] = 1
+        conncomp[conncomp2_mask] = 2
+
+        # Partition the connected components array into a 2x2 grid of tiles such that
+        # each connected component spans all 4 tiles.
+        tiles = tophu.TiledPartition((length, width), ntiles=(2, 2))
+
+        # De-duplicate labels from different tiles.
+        tophu.deduplicate_labels(conncomp, tiles)
+
+        # After re-labeling, there should be no common labels between different tiles
+        # (except for masked-out pixels with label 0). Get the set of unique labels
+        # within each tile and check that each pair of sets is disjoint (has no common
+        # elements).
+        tile_label_sets = [
+            tophu.unique_nonzero_integers(conncomp[tile]) for tile in tiles
+        ]
+        for set1, set2 in itertools.combinations(tile_label_sets, r=2):
+            assert set1.isdisjoint(set2)
+
+        # Since both connected components spanned all 4 tiles, the relabeled connected
+        # components should each consist of 4 unique labels.
+        conncomp1_labels = set(np.unique(conncomp[conncomp1_mask]))
+        conncomp2_labels = set(np.unique(conncomp[conncomp2_mask]))
+        assert len(conncomp1_labels) == 4
+        assert len(conncomp2_labels) == 4
+        assert conncomp1_labels.isdisjoint(conncomp2_labels)
+
+        # Each masked-out pixel should still be labeled 0.
+        invalid_mask = ~(conncomp1_mask | conncomp2_mask)
+        assert np.all(conncomp[invalid_mask] == 0)
+
+    def test3(self):
+        # Simulate a randomized array of connected component labels.
+        shape = (128, 128)
+        conncomp = random_conncomp_labels(shape, density=0.6)
+
+        # De-duplicate labels from different tiles.
+        tiles = tophu.TiledPartition(shape, ntiles=(2, 2))
+        tophu.deduplicate_labels(conncomp, tiles)
+
+        # After re-labeling, there should be no common labels between different tiles
+        # (except for masked-out pixels with label 0). Get the set of unique labels
+        # within each tile and check that each pair of sets is disjoint (has no common
+        # elements).
+        tile_label_sets = [
+            tophu.unique_nonzero_integers(conncomp[tile]) for tile in tiles
+        ]
+        for set1, set2 in itertools.combinations(tile_label_sets, r=2):
+            assert set1.isdisjoint(set2)
+
+
+class TestMergeEquivalentLabels:
+    def test(self):
+        length, width = 1280, 256
+
+        # Create two connected components: one tall "U"-shaped component and one
+        # rectangular-shaped component.
+        conncomp1_mask = np.zeros((length, width), dtype=np.bool_)
+        conncomp1_mask[50:1000, 50:100] = True
+        conncomp1_mask[50:1000, -100:-50] = True
+        conncomp1_mask[1000:1050, 50:-50] = True
+
+        conncomp2_mask = np.zeros((length, width), dtype=np.bool_)
+        conncomp2_mask[1100:-50, 50:-50] = True
+
+        conncomp = np.zeros((length, width), dtype=np.uint32)
+        conncomp[conncomp1_mask] = 1
+        conncomp[conncomp2_mask] = 3
+
+        # Update the connected component labels in each tile so that each component is
+        # associated with multiple redundant labels.
+        tiles = tophu.TiledPartition((length, width), ntiles=(5, 2))
+        for i, tile in enumerate(tiles):
+            nonzero_mask = conncomp[tile] != 0
+            conncomp[tile][nonzero_mask] += i
+
+        # Merge equivalent labels.
+        new_conncomp = tophu.merge_equivalent_labels(conncomp, tiles)
+
+        # Checks whether every value in the input array is exactly the same. The array
+        # must not be empty.
+        def all_same(x: NDArray) -> bool:
+            return np.all(x == x.flat[0])
+
+        # After relabeling, all pixels within each connected component should have the
+        # same label.
+        for mask in [conncomp1_mask, conncomp2_mask]:
+            assert all_same(new_conncomp[mask])
+
+        # The two connected components should have different labels.
+        conncomp1_labels = set(np.unique(new_conncomp[conncomp1_mask]))
+        conncomp2_labels = set(np.unique(new_conncomp[conncomp2_mask]))
+        assert conncomp1_labels.isdisjoint(conncomp2_labels)
+
+        # Outside of the two connected components, all pixels should be filled with
+        # zeros.
+        invalid_mask = ~(conncomp1_mask | conncomp2_mask)
+        assert np.all(new_conncomp[invalid_mask] == 0)
+
+    def test_output_labels(self):
+        # Generate an initial set of connected components but add 100 to each connected
+        # component label.
+        shape = (128, 128)
+        conncomp = random_conncomp_labels(shape, density=0.6)
+        conncomp[conncomp != 0] += 100
+
+        # Relabel.
+        tiles = tophu.TiledPartition(shape, ntiles=(3, 3))
+        new_conncomp = tophu.merge_equivalent_labels(conncomp, tiles)
+
+        # The new connected components should be labeled [1, 2, ..., N], where N is the
+        # total number of connected components, regardless of the initial connected
+        # component labels.
+        nlabels = len(tophu.unique_nonzero_integers(conncomp))
+        assert np.all(np.unique(new_conncomp) == np.arange(nlabels + 1))
+
+    def test_connectivity(self):
+        length, width = 128, 128
+        conncomp = np.zeros((length, width), dtype=np.uint32)
+
+        # Divide the connected component labels array into quadrants. Fill the
+        # upper-left quadrant with ones and the lower-right quadrant with twos. The
+        # remaining quadrants are filled with zeros.
+        halflength = length // 2
+        halfwidth = width // 2
+        conncomp[:halflength, :halfwidth] = 1
+        conncomp[halflength:, halfwidth:] = 2
+
+        tiles = tophu.TiledPartition((length, width), ntiles=(2, 2))
+
+        # With `connectivity=1`, the two nonzero quadrants are considered disconnected,
+        # so `merge_equivalent_labels()` has no effect.
+        new_conncomp = tophu.merge_equivalent_labels(conncomp, tiles, connectivity=1)
+        assert np.all(new_conncomp == conncomp)
+
+        # But with `connectivity=2`, the two nonzero quadrants are connected via a
+        # single pair of diagonal neighbors, so they should be merged into a single
+        # connected component.
+        new_conncomp = tophu.merge_equivalent_labels(conncomp, tiles, connectivity=2)
+        assert np.all(new_conncomp == np.minimum(conncomp, 1))
+
+    def test_bad_connectivity(self):
+        shape = (128, 128)
+        conncomp = random_conncomp_labels(shape, density=0.6)
+        tiles = tophu.TiledPartition(shape, ntiles=(2, 2))
+
+        # Check that an error is raised if the value of `connectivity` is invalid.
+        with pytest.raises(ValueError):
+            tophu.merge_equivalent_labels(conncomp, tiles, connectivity=3)

--- a/test/test_label.py
+++ b/test/test_label.py
@@ -117,9 +117,9 @@ class TestDeduplicateLabels:
         tophu.deduplicate_labels(conncomp, tiles)
 
         # After re-labeling, there should be no common labels between different tiles
-        # (except for masked-out pixels with label 0). Get the set of unique labels
-        # within each tile and check that each pair of sets is disjoint (has no common
-        # elements).
+        # (except for masked-out pixels with label 0). Get the set of unique nonzero
+        # labels within each tile and check that each pair of sets is disjoint (has no
+        # common elements).
         tile_label_sets = [
             tophu.unique_nonzero_integers(conncomp[tile]) for tile in tiles
         ]
@@ -148,9 +148,9 @@ class TestDeduplicateLabels:
         tophu.deduplicate_labels(conncomp, tiles)
 
         # After re-labeling, there should be no common labels between different tiles
-        # (except for masked-out pixels with label 0). Get the set of unique labels
-        # within each tile and check that each pair of sets is disjoint (has no common
-        # elements).
+        # (except for masked-out pixels with label 0). Get the set of unique nonzero
+        # labels within each tile and check that each pair of sets is disjoint (has no
+        # common elements).
         tile_label_sets = [
             tophu.unique_nonzero_integers(conncomp[tile]) for tile in tiles
         ]

--- a/test/test_multiscale.py
+++ b/test/test_multiscale.py
@@ -237,8 +237,8 @@ class TestMultiScaleUnwrap:
             )
             assert frac_nonzero(good_pixels) > 0.999
 
-        # Check the connected component labels. There should be two connected
-        # components, labeled 1 and 2, as well as masked-out pixels labeled 0.
+        # Check the set of unique connected component labels. There should be two
+        # connected components, labeled 1 and 2, as well as masked-out pixels labeled 0.
         assert set(np.unique(conncomp)) == {0, 1, 2}
 
         # Check that each high-coherence region is associated with a single connected

--- a/test/test_union_find.py
+++ b/test/test_union_find.py
@@ -1,0 +1,336 @@
+from collections.abc import Iterable
+
+import pytest
+
+import tophu
+
+
+def count(iterable: Iterable) -> int:
+    """Count the number of items in an iterable."""
+    return sum(1 for _ in iterable)
+
+
+class TestDisjointSetForest:
+    def test_default_init(self):
+        # Check that a default-constructed `DisjointSetForest` is empty.
+        forest = tophu.DisjointSetForest()
+        items = list(forest.items())
+        assert len(items) == 0
+
+    def test_init(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b", "c", "d"}
+        forest = tophu.DisjointSetForest(items)
+
+        # Check the contents of the forest.
+        assert set(forest.items()) == items
+
+        # Check that each item is its own disjoint subset.
+        for item in forest.items():
+            assert forest.find(item) == item
+
+    def test_init_duplicate_item(self):
+        # Check that `DisjointSetForest` only stores unique items upon construction.
+        # Duplicate items are discarded.
+        items = ["a", "b", "c", "b"]
+        forest = tophu.DisjointSetForest(items)
+        assert forest.num_items() == 3
+        assert list(forest.items()) == ["a", "b", "c"]
+
+    def test_contains(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b", "c", "d"}
+        forest = tophu.DisjointSetForest(items)
+
+        # Test `contains()` method.
+        assert forest.contains("b")
+        assert not forest.contains("e")
+
+        # Test `in` and `not in` operators.
+        assert "b" in forest
+        assert "e" not in forest
+
+    def test_add_item(self):
+        forest = tophu.DisjointSetForest()
+        assert "a" not in forest
+
+        forest.add_item("a")
+        assert "a" in forest
+
+        assert forest.find("a") == "a"
+
+    def test_add_duplicate_item(self):
+        forest = tophu.DisjointSetForest()
+        forest.add_item("a")
+        forest.add_item("b")
+
+        # Check that adding a duplicate item has no effect.
+        forest.add_item("a")
+        assert forest.num_items() == 2
+        assert forest.get_parent("a") == "a"
+        assert forest.get_parent("b") == "b"
+
+        # Adding a duplicate of an existing item should not affect the parent of the
+        # existing item.
+        forest.set_parent("a", "b")
+        forest.add_item("a")
+        assert forest.get_parent("a") == "b"
+
+    def test_add_items(self):
+        # Construct an empty `DisjointSetForest`.
+        forest = tophu.DisjointSetForest()
+
+        # Add items.
+        items = {"a", "b", "c", "d"}
+        forest.add_items(items)
+
+        # Check the contents of the forest.
+        assert set(forest.items()) == items
+
+        # Check that each item is its own disjoint subset.
+        for item in forest.items():
+            assert forest.find(item) == item
+
+    def test_iter(self):
+        # Construct a disjoint-set forest and add some items to it.
+        forest = tophu.DisjointSetForest(["a", "b", "c"])
+        forest.add_item("d")
+        forest.add_item("e")
+
+        # Test iterating over the forest. The iteration order should match the order in
+        # which items were added to the forest.
+        items = [item for item in forest]
+        assert items == ["a", "b", "c", "d", "e"]
+
+        # Test the `items()` method.
+        items = list(forest.items())
+        assert items == ["a", "b", "c", "d", "e"]
+
+    def test_roots(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b", "c", "d"}
+        forest = tophu.DisjointSetForest(items)
+
+        # Initially, each node in the forest is a root node.
+        assert forest.roots() == items
+
+        # Test the `roots()` method after growing trees.
+        forest.set_parent("a", "b")
+        forest.set_parent("c", "d")
+        assert forest.roots() == {"b", "d"}
+
+        forest.set_parent("b", "d")
+        assert forest.roots() == {"d"}
+
+    def test_len(self):
+        forest = tophu.DisjointSetForest()
+        assert len(forest) == 0
+
+        items = {"a", "b", "c", "d"}
+        forest = tophu.DisjointSetForest(items)
+        assert len(forest) == 4
+
+        forest.add_item("e")
+        assert len(forest) == 5
+
+    def test_num_items(self):
+        forest = tophu.DisjointSetForest()
+        assert forest.num_items() == 0
+
+        items = {"a", "b", "c", "d"}
+        forest = tophu.DisjointSetForest(items)
+        assert forest.num_items() == 4
+
+        forest.add_item("e")
+        assert forest.num_items() == 5
+
+    def test_num_trees(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b", "c", "d"}
+        forest = tophu.DisjointSetForest(items)
+
+        # Initially, each node in the forest is a singleton tree.
+        assert forest.num_trees() == forest.num_items()
+
+        # Merge some trees.
+        forest.union("a", "b")
+        forest.union("c", "d")
+        assert forest.num_trees() == 2
+
+        forest.union("b", "d")
+        assert forest.num_trees() == 1
+
+    def test_eq(self):
+        forest1 = tophu.DisjointSetForest({"a", "b", "c"})
+        forest2 = tophu.DisjointSetForest({"a", "b", "c"})
+        forest3 = tophu.DisjointSetForest({"A", "B", "C"})
+
+        # Test equality comparison.
+        assert forest1 == forest2
+        assert forest1 != forest3
+
+        # Test equality comparison against other types.
+        assert forest1 != "asdf"
+
+        # Equality comparison should be sensitive to the topology of the underlying
+        # graph.
+        forest2.set_parent("a", "b")
+        assert forest1 != forest2
+
+    def test_copy(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b", "c"}
+        forest = tophu.DisjointSetForest(items)
+
+        # Create a copy.
+        copy = forest.copy()
+
+        # The copy should be equivalent to the original.
+        assert copy == forest
+
+        # Modifying the copy should not affect the original.
+        copy.set_parent("a", "b")
+        assert forest.get_parent("a") != "b"
+        assert copy != forest
+
+    def test_get_parent(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b"}
+        forest = tophu.DisjointSetForest(items)
+
+        # Initially, each item should be a root node (its parent node is itself).
+        assert forest.get_parent("a") == "a"
+        assert forest.get_parent("b") == "b"
+
+        # After setting the parent node, `get_parent()` should return the new parent.
+        forest.set_parent("a", "b")
+        assert forest.get_parent("a") == "b"
+        assert forest.get_parent("b") == "b"
+
+    def test_bad_get_parent(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b", "c", "d"}
+        forest = tophu.DisjointSetForest(items)
+
+        # Check that `get_parent()` fails if the input item is not part of the set.
+        with pytest.raises(ValueError, match="item not found: e"):
+            forest.get_parent("e")
+
+    def test_bad_set_parent(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b", "c", "d"}
+        forest = tophu.DisjointSetForest(items)
+
+        # Check that `set_parent()` fails if either the parent or child was not already
+        # part of the set.
+        with pytest.raises(ValueError, match="item not found: e"):
+            forest.set_parent("e", "a")
+        with pytest.raises(ValueError, match="item not found: e"):
+            forest.set_parent("a", "e")
+
+    def test_iter_parents(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b", "c", "d"}
+        forest = tophu.DisjointSetForest(items)
+
+        # Form a single linear tree by assigning parents.
+        forest.set_parent("a", "b")
+        forest.set_parent("b", "c")
+        forest.set_parent("c", "d")
+
+        # Check each node's ancestors.
+        assert list(forest.iter_parents("a")) == ["b", "c", "d"]
+        assert list(forest.iter_parents("b")) == ["c", "d"]
+        assert list(forest.iter_parents("c")) == ["d"]
+        assert list(forest.iter_parents("d")) == []
+
+    def test_find(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b", "c", "d", "e", "f"}
+        forest = tophu.DisjointSetForest(items)
+
+        # Form a tree containing {'a', 'b', 'c', 'd'} (with 'a' and 'c' as sister
+        # nodes), and another tree containing {'e', 'f'}.
+        forest.set_parent("a", "b")
+        forest.set_parent("c", "b")
+        forest.set_parent("b", "d")
+        forest.set_parent("e", "f")
+
+        # Test the `find()` method.
+        for item in ["a", "b", "c", "d"]:
+            assert forest.find(item) == "d"
+        for item in ["e", "f"]:
+            assert forest.find(item) == "f"
+
+    def test_union(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b", "c", "d", "e"}
+        forest = tophu.DisjointSetForest(items)
+
+        # Check that 'a' and 'b' belong to disjoint subsets before the `union()`
+        # operation but not afterwards.
+        assert forest.is_disjoint("a", "b")
+        forest.union("a", "b")
+        assert not forest.is_disjoint("a", "b")
+
+        # Merge the subsets containing 'c' and 'd'.
+        forest.union("c", "d")
+
+        # Currently, {'a', 'b'} and {'c', 'd'} are two disjoint subsets. Check that 'a'
+        # and 'd' belong to disjoint subsets before invoking `union('b', 'c')`, but not
+        # afterwards.
+        assert forest.is_disjoint("a", "d")
+        forest.union("b", "c")
+        assert not forest.is_disjoint("a", "d")
+
+        # Each item in the forest except for 'e' should now have the same root node.
+        root = forest.find("a")
+        for item in ["b", "c", "d"]:
+            assert forest.find(item) == root
+        assert forest.find("e") != root
+
+    def test_union_noop(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b", "c"}
+        forest = tophu.DisjointSetForest(items)
+        forest.union("a", "b")
+        forest.union("b", "c")
+
+        # Check that `union()` has no effect if the two subsets were already merged.
+        copy = forest.copy()
+        forest.union("a", "c")
+        assert forest == copy
+
+    def test_flatten(self):
+        # Construct a disjoint-set forest.
+        items = {"a", "b", "c", "d", "e", "f"}
+        forest = tophu.DisjointSetForest(items)
+
+        # Form a tree containing {'a', 'b', 'c', 'd'} (with 'a' and 'c' as sister
+        # nodes), and another tree containing {'e', 'f'}.
+        forest.set_parent("a", "b")
+        forest.set_parent("c", "b")
+        forest.set_parent("b", "d")
+        forest.set_parent("e", "f")
+
+        # Check that flattening does not affect the result of the `find()` operation for
+        # each node in the forest.
+        old_roots = forest.roots()
+        forest.flatten()
+        new_roots = forest.roots()
+        assert old_roots == new_roots
+
+        # After flattening, each node's parent should be the root of the tree to which
+        # it belongs.
+        for item in forest.items():
+            assert forest.get_parent(item) == forest.find(item)
+
+        # Get the number of ancestors of a node in the forest (i.e. its depth within the
+        # corresponding tree).
+        def num_ancestors(item):
+            ancestors = forest.iter_parents(item)
+            return count(ancestors)
+
+        # After flattening, each node in the forest should have at most 1 ancestor.
+        for item in forest.items():
+            assert num_ancestors(item) <= 1

--- a/test/test_union_find.py
+++ b/test/test_union_find.py
@@ -60,9 +60,14 @@ class TestDisjointSetForest:
         assert forest.find("a") == "a"
 
     def test_add_duplicate_item(self):
+        # Construct a disjoint-set forest and add some items to it.
         forest = tophu.DisjointSetForest()
         forest.add_item("a")
         forest.add_item("b")
+
+        assert forest.num_items() == 2
+        assert forest.get_parent("a") == "a"
+        assert forest.get_parent("b") == "b"
 
         # Check that adding a duplicate item has no effect.
         forest.add_item("a")
@@ -315,9 +320,9 @@ class TestDisjointSetForest:
 
         # Check that flattening does not affect the result of the `find()` operation for
         # each node in the forest.
-        old_roots = forest.roots()
+        old_roots = [forest.find(item) for item in forest.items()]
         forest.flatten()
-        new_roots = forest.roots()
+        new_roots = [forest.find(item) for item in forest.items()]
         assert old_roots == new_roots
 
         # After flattening, each node's parent should be the root of the tree to which

--- a/test/test_union_find.py
+++ b/test/test_union_find.py
@@ -202,7 +202,7 @@ class TestDisjointSetForest:
         assert forest.get_parent("a") == "a"
         assert forest.get_parent("b") == "b"
 
-        # After setting the parent node, `get_parent()` should return the new parent.
+        # After setting a new parent node, `get_parent()` should return the new parent.
         forest.set_parent("a", "b")
         assert forest.get_parent("a") == "b"
         assert forest.get_parent("b") == "b"


### PR DESCRIPTION
This PR adds two additional steps to the multiscale unwrapping pipeline in order to address inconsistencies in connected component labels from different tiles.

1. The first step, `deduplicate_labels()`, de-duplicates connected component labels from different tiles so that no tile has any label in common with other tiles. This is necessary because independently unwrapped tiles may produce different connected components with the same label.

   The procedure for de-duplicating labels is straightforward and involves visiting each tile sequentially and adding the maximum label value from among previously visited tiles to each labeled pixel in the current tile.

2. The second step, `merge_equivalent_labels()`, finds and merges any equivalent labels so that each connected component is associated with a single unique label. This is necessary because connected components that spanned multiple tiles may have been assigned multiple redundant labels.

   The label merging step uses a two-pass algorithm to determine the final set of connected components. In the first pass, the initial labels are scanned and label equivalence information is stored in a [Union-Find data structure](https://en.wikipedia.org/wiki/Disjoint-set_data_structure). Each set of equivalent  labels is associated with a unique final label. A second pass through the data assigns each pixel its final label.

   The Union-Find implementation is very simple and not well-optimized. There are lots of optimizations, like path compression [^1] or an array-based implementation [^2], which we could consider adding in the future to speed this step up, but I think it's very unlikely to ever be a bottleneck.

   The final labels are the sequence of natural numbers [1, 2, ..., N], where N is the total number of connected components.

[^1]: Fiorio, Christophe et al. "Two linear time Union-Find strategies for image processing". Theoretical Computer Science 154. 2(1996): 165–181.

[^2]: Kesheng Wu, et al. "Optimizing two-pass connected-component labeling algorithms". Pattern Analysis and Applications 12. 2(2008): 117–135.