### PR TITLE
Relabel multiscale connected components

### DIFF
--- a/src/tophu/__init__.py
+++ b/src/tophu/__init__.py
@@ -1,5 +1,6 @@
 from ._filter import *
 from ._io import *
+from ._label import *
 from ._multilook import *
 from ._multiscale import *
 from ._unwrap import *

--- a/src/tophu/_label.py
+++ b/src/tophu/_label.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import itertools
+from collections.abc import Mapping
+from typing import Any
+
+import dask.array as da
+import numpy as np
+from numpy.typing import NDArray
+
+from ._util import get_all_unique_values, mode, unique_nonzero_integers
+
+__all__ = [
+    "relabel_hires_conncomps",
+]
+
+
+# A constant used to identify high-res connected components that don't overlap with any
+# low-res component.
+NO_OVERLAPPING_LABEL = -1
+
+
+def find_max_overlapping_labels(
+    src_conncomp: NDArray[np.unsignedinteger],
+    dst_conncomp: NDArray[np.unsignedinteger],
+    *,
+    min_overlap: float = 0.5,
+) -> dict[int, int]:
+    """
+    Find overlapping connected components.
+
+    Given two sets of connected component labels, find the labels in the second set that
+    most overlap with each label in the first set. That is, for each unique label in
+    `src_conncomp`, compute the label from `dst_conncomp` that it has the largest
+    intersecting area with, if any such label exists.
+
+    The ratio of the intersecting area to the area of the original component must be at
+    least `min_overlap` for the two components to be considered overlapping. The special
+    constant `NO_OVERLAPPING_LABEL` is used to identify labels from `src_conncomp` that
+    did not sufficiently overlap with any connected component from `dst_conncomp`.
+
+    Zero-valued elements are not considered to be members of any connected component.
+
+    Parameters
+    ----------
+    src_conncomp : numpy.ndarray
+        The initial set of connected component labels. An array of nonnegative integers.
+    dst_conncomp : numpy.ndarray
+        The second set of connected component labels. An array of nonnegative integers
+        with the same shape as `src_conncomp`.
+    min_overlap : float, optional
+        Minimum intersection between components in order to be considered overlapping,
+        as a fraction of the area of the component from `src_conncomp`. Must be in the
+        range (0, 1]. Defaults to 0.5.
+
+    Returns
+    -------
+    overlapping_labels : dict
+        A mapping from each unique label in `src_conncomp` to the label in
+        `dst_conncomp` that it most overlapped with, or to `NO_OVERLAPPING_LABEL` if no
+        connected component was found that satisfied the minimum overlap threshold.
+    """
+    if dst_conncomp.shape != src_conncomp.shape:
+        raise ValueError(
+            "shape mismatch: input connected components arrays must have the same shape"
+        )
+
+    if min_overlap <= 0.0:
+        raise ValueError(f"min overlap must be > 0, got {min_overlap}")
+    if min_overlap > 1.0:
+        raise ValueError(f"min overlap must be <= 1, got {min_overlap}")
+
+    # Get the set of unique labels in the first array of connected components (CCs).
+    src_labels = unique_nonzero_integers(src_conncomp)
+
+    # Get a mask of nonzero values in the second array of CCs.
+    dst_nonzero = dst_conncomp != 0
+
+    # Given a label from `src_labels`, find the label of the CC from `dst_conncomp` that
+    # had the most overlapping area with the corresponding CC in `src_conncomp` (if any
+    # exists). If no label was found that satisfied the minimum overlap threshold,
+    # returns `NO_OVERLAPPING_LABEL`.
+    def get_max_overlapping_label(src_label: int) -> int:
+        # Get a mask of pixels within the current CC.
+        cc_mask = src_conncomp == src_label
+
+        # Get the total area of the CC (i.e. the number of nonzero values in the mask).
+        cc_area = np.count_nonzero(cc_mask)
+
+        # Get the most frequent label from `dst_conncomp` within the masked region.
+        dst_label, count = mode(dst_conncomp[cc_mask & dst_nonzero])
+
+        # Check whether there was sufficient overlap between the two labels.
+        if count >= min_overlap * cc_area:
+            return dst_label
+        else:
+            return NO_OVERLAPPING_LABEL
+
+    return {src_label: get_max_overlapping_label(src_label) for src_label in src_labels}
+
+
+def relabel(
+    conncomp: NDArray[np.unsignedinteger],
+    label_mapping: Mapping[int, int],
+) -> NDArray[np.unsignedinteger]:
+    """
+    Replace each label in `conncomp` with a new label from `label_mapping`.
+
+    Given an array of provisional connected component labels `conncomp` and a mapping
+    from provisional labels to final labels `label_mapping`, create a new array of
+    connected component labels by replacing each provisional label with the
+    corresponding final label.
+
+    The set of unique nonzero labels in `conncomp` must be a subset of the keys of
+    `label_mapping`.
+
+    Zero-valued elements of `conncomp` are treated as masked out (i.e. not part of any
+    connected component). They are not relabeled.
+
+    Parameters
+    ----------
+    conncomp : numpy.ndarray
+        The input array of provisional connected component labels. This array is not
+        modified by the function.
+    label_mapping : mapping
+        Defines a mapping from each unique nonzero label in `conncomp` to the
+        corresponding final label to assign to that component.
+
+    Returns
+    -------
+    relabeled : numpy.ndarray
+        A new array with the same shape and dtype as `conncomp` resulting from replacing
+        each input connected component label with the corresponding label from
+        `label_mapping`.
+    """
+    # Create the new connected components (CC) array, initially filled with zeros.
+    new_conncomp = np.zeros_like(conncomp)
+
+    # Loop over unique CC labels in the original `conncomp` array.
+    for old_label in unique_nonzero_integers(conncomp):
+        # Get a mask of pixels within the current CC.
+        mask = conncomp == old_label
+
+        # Get the corresponding final label.
+        new_label = label_mapping[old_label]
+
+        # Assign the new label to masked pixels in the output array.
+        new_conncomp[mask] = new_label
+
+    return new_conncomp
+
+
+def extract_scalar(arr: np.ndarray) -> Any:
+    """Extract the scalar value from an array containing a single element."""
+    if arr.size != 1:
+        raise ValueError(f"array size must be equal to 1, got {arr.size}")
+    return np.squeeze(arr)[()]
+
+
+def relabel_hires_conncomps(
+    conncomp_hires: da.Array,
+    conncomp_lores: da.Array,
+    *,
+    min_overlap: float = 0.5,
+) -> da.Array:
+    """
+    Deduplicate and merge connected component labels resulting from tiled unwrapping.
+
+    If a high-resolution interferogram is unwrapped by tiles, each tile may be assigned
+    a set of connected component (CC) labels independently from the surrounding tiles.
+    As a result, some CC labels may not be unique across tiles. Furthermore, if regions
+    of reliable unwrapped phase spanned multiple tiles, they may be assigned different
+    labels in different tiles.
+
+    This function attempts to resolve these issues as a post-processing step by using a
+    set of low-resolution CCs resulting from coarse unwrapping of the same
+    interferogram. Unlike the high-resolution CCs, each low-resolution CC is assumed to
+    be assigned a single unique label.
+
+    For each high-resolution CC in each tile, the low-resolution CC that it shares the
+    most overlapping area with is found. Then each CC is relabeled according to the
+    low-resolution CC that it most overlapped with. If two or more high-resolution
+    components share the same most-overlapping low-resolution CC, then they will be
+    assigned the same label. High-resolution CCs that most overlapped with different
+    low-resolution CCs will be assigned distinct labels. Each high-resolution CC that
+    did not overlap with any low-resolution CC will be assigned a unique label.
+
+    After relabeling, each unique connected component is assigned a new positive integer
+    label in [1, 2, ..., N], where N is the total number of unique connected components.
+
+    Zero-valued pixels are treated as masked out (i.e. not part of any connected
+    component). They are not relabeled.
+
+    Parameters
+    ----------
+    conncomp_hires : dask.array.Array
+        The initial high-resolution connected components. A two-dimensional array of
+        nonnegative integer values. Each chunk of the array is assumed to have been
+        independently assigned its connected component labels, such that labels may not
+        be unique across chunks and some components that span multiple chunks may have
+        been assigned multiple labels.
+    conncomp_lores : dask.array.Array
+        An array of connected component labels resulting from coarse unwrapping. A
+        two-dimensional array of nonnegative integer values with the same shape and
+        chunk sizes as `conncomp_hires`. Unlike the high-resolution connected
+        components, each connected component in `conncomp_lores` is assumed to be
+        assigned a single unique label.
+    min_overlap : float, optional
+        Minimum intersection between components in order to be considered overlapping,
+        as a fraction of the area of the high-resolution component area. Must be in the
+        range (0, 1]. Defaults to 0.5.
+
+    Returns
+    -------
+    new_conncomp_hires : dask.array.Array
+        The array of updated high-resolution connected component labels.
+    """
+    # The high-res and low-res connected component (CC) arrays should each be 2-D arrays
+    # with the same shape & chunk sizes.
+    if conncomp_hires.ndim != 2:
+        raise ValueError("the input connected components must be 2-D arrays")
+    if conncomp_hires.shape != conncomp_lores.shape:
+        raise ValueError(
+            "shape mismatch: the high-res and low-res connected components arrays must"
+            " have the same shape"
+        )
+    if conncomp_hires.chunks != conncomp_lores.chunks:
+        raise ValueError(
+            "the high-res and low-res connected components arrays must have the same"
+            " chunk sizes"
+        )
+
+    # For each high-res CC in each tile, find the label of the low-res CC that most
+    # overlapped with it, if any such component exists. The result is an array with
+    # shape equal to `conncomp_hires.numblocks` of dicts mapping from high-res labels to
+    # the corresponding low-res labels (one dict per tile).
+    label_mappings = da.map_blocks(
+        lambda cc_hires, cc_lores, min_overlap: np.atleast_2d(
+            find_max_overlapping_labels(cc_hires, cc_lores, min_overlap=min_overlap)
+        ),
+        conncomp_hires,
+        conncomp_lores,
+        min_overlap=min_overlap,
+        meta=np.empty((), dtype=np.object_),
+    ).compute()
+
+    # Get the set of all low-res CC labels from among all tiles that overlapped with any
+    # high-res CC. This is the set of all unique values (not keys) from among dicts in
+    # `label_mappings`.
+    mapped_labels = get_all_unique_values(label_mappings.flat)
+
+    # An inexhaustible generator that yields new unique positive-valued connected
+    # component labels not found in the set of existing low-res labels.
+    new_unique_labels = (
+        label for label in itertools.count(1) if label not in mapped_labels
+    )
+
+    # Update the label mappings to replace `NO_OVERLAPPING_LABEL` values with new unique
+    # labels.
+    for label_mapping in label_mappings.flat:
+        for key, val in label_mapping.items():
+            if val == NO_OVERLAPPING_LABEL:
+                label_mapping[key] = next(new_unique_labels)
+
+    # Once more, get the set of all mapped-to labels in `label_mappings` after we
+    # finished updating it to replace `NO_OVERLAPPING_LABEL` values with new labels.
+    updated_mapped_labels = get_all_unique_values(label_mappings.flat)
+
+    # We would like the final set of connected component labels to be the set of natural
+    # numbers 1 through N, where N is the total number of connected components.
+    # Currently, that's not necessarily the case in `updated_mapped_labels` -- due to
+    # merging of equivalent labels, there could be some "gaps" in the natural sequence
+    # of labels. So we define an additional mapping from `updated_mapped_labels` to the
+    # set of final labels, which will be the natural numbers 1 through N.
+    final_labels = dict(zip(updated_mapped_labels, itertools.count(1)))
+
+    # Create a new array of label mappings, with one dict per tile in the original
+    # high-res CC array. Each dict defines a mapping from the original high-res
+    # labels to the corresponding final labels for each CC in the tile.
+    final_label_mappings = label_mappings.copy()
+    for label_mapping in final_label_mappings.flat:
+        for key, val in label_mapping.items():
+            label_mapping[key] = final_labels[val]
+
+    # Break the `final_label_mappings` array up into chunks (one chunk per tile in the
+    # input `conncomp_hires` array).
+    final_label_mappings = da.from_array(final_label_mappings, chunks=(1, 1))
+    assert final_label_mappings.numblocks == conncomp_hires.numblocks
+
+    # Finally, create the output array of updated connected component labels by
+    # replacing each high-res connected component label with the new corresponding label
+    # from `final_label_mappings`.
+    return da.map_blocks(
+        lambda conncomp, label_mapping: relabel(
+            conncomp, extract_scalar(label_mapping)
+        ),
+        conncomp_hires,
+        final_label_mappings,
+        meta=conncomp_hires._meta,
+    )

--- a/src/tophu/_util.py
+++ b/src/tophu/_util.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+import operator
+import os
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from functools import reduce
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, TypeVar
 
 import dask.array as da
 import numpy as np
@@ -10,11 +17,21 @@ from numpy.typing import ArrayLike, NDArray
 __all__ = [
     "as_tuple_of_int",
     "ceil_divide",
+    "get_all_unique_values",
     "get_lock",
+    "get_tile_dims",
     "iseven",
     "map_blocks",
+    "merge_sets",
+    "mode",
     "round_up_to_next_multiple",
+    "scratch_directory",
+    "unique_nonzero_integers",
 ]
+
+
+# A generic type, without constraints.
+T = TypeVar("T")
 
 
 def as_tuple_of_int(ints: int | Iterable[int]) -> tuple[int, ...]:
@@ -61,6 +78,12 @@ def ceil_divide(n: ArrayLike, d: ArrayLike) -> NDArray:
     return (n + d - np.sign(d)) // d
 
 
+def get_all_unique_values(dicts: Iterable[dict[Any, T]]) -> set[T]:
+    """Get the set of all unique values (not keys) in a sequence of dicts."""
+    unique_values_per_dict = (set(d.values()) for d in dicts)
+    return merge_sets(unique_values_per_dict)
+
+
 def get_lock():
     """Get a lock appropriate for the current Dask scheduler."""
     import dask.base
@@ -77,6 +100,65 @@ def get_lock():
         pass
 
     return dask.utils.get_scheduler_lock(scheduler=client_or_scheduler)
+
+
+def get_tile_dims(
+    shape: tuple[int, ...],
+    ntiles: tuple[int, ...],
+    snap_to: tuple[int, ...] | None = None,
+) -> tuple[int, ...]:
+    """
+    Get tile dimensions of an array partitioned into tiles.
+
+    Chooses tile dimensions such that an array of shape `shape` will be subdivided into
+    blocks of roughly equal shape.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        Shape of the array to be partitioned into tiles.
+    ntiles : tuple of int
+        Number of tiles along each array axis. Must be the same length as `shape`.
+    snap_to : tuple of int or None, optional
+        If specified, force tile dimensions to be a multiple of this value. Defaults to
+        None.
+
+    Returns
+    -------
+    tiledims : tuple of int
+        Shape of a typical tile. The last tile along each axis may be smaller.
+    """
+    # Normalize `shape` and `ntiles` into tuples of ints.
+    shape = as_tuple_of_int(shape)
+    ntiles = as_tuple_of_int(ntiles)
+
+    # Number of dimensions of the partitioned array.
+    ndim = len(shape)
+
+    if len(ntiles) != ndim:
+        raise ValueError("size mismatch: shape and ntiles must have same length")
+    if any(map(lambda s: s < 1, shape)):
+        raise ValueError("array axis lengths must be >= 1")
+    if any(map(lambda n: n < 1, ntiles)):
+        raise ValueError("number of tiles must be >= 1")
+
+    tiledims = ceil_divide(shape, ntiles)
+
+    if snap_to is not None:
+        # Normalize `snap_to` to a tuple of ints.
+        snap_to = as_tuple_of_int(snap_to)
+
+        if len(snap_to) != ndim:  # type: ignore[arg-type]
+            raise ValueError("size mismatch: shape and snap_to must have same length")
+        if any(map(lambda s: s < 1, snap_to)):  # type: ignore[arg-type]
+            raise ValueError("snap_to lengths must be >= 1")
+
+        tiledims = round_up_to_next_multiple(tiledims, snap_to)
+
+    # Tile dimensions should not exceed the full array dimensions.
+    tiledims = tuple(np.minimum(tiledims, shape))
+
+    return tiledims
 
 
 def iseven(n: int) -> bool:
@@ -107,6 +189,42 @@ def map_blocks(func, *args, **kwargs) -> da.Array | tuple[da.Array, ...]:
     return out
 
 
+def merge_sets(sets: Iterable[set[T]]) -> set[T]:
+    """Return a new set that is the union of all of the input sets."""
+    initial: set[T] = set()
+    return reduce(operator.or_, sets, initial)
+
+
+def mode(arr: ArrayLike) -> tuple[np.ndarray, int]:
+    """
+    Get the modal (most common) value in the input array.
+
+    If there is more than one such value, only one is returned.
+
+    The mode of an empty array is NaN, and the associated count is zero.
+
+    Parameters
+    ----------
+    arr : array_like
+        The input array.
+
+    Returns
+    -------
+    mode : numpy.ndarray
+        The modal value.
+    count : int
+        The number of times the mode appeared in the array.
+    """
+    arr = np.asanyarray(arr)
+
+    if arr.size == 0:
+        return np.nan, 0
+
+    vals, counts = np.unique(arr, return_counts=True)
+    idx = np.argmax(counts)
+    return vals[idx], counts[idx]
+
+
 def round_up_to_next_multiple(n: ArrayLike, base: ArrayLike) -> NDArray:
     """Round up to the next smallest multiple of `base`."""
     n = np.asanyarray(n)
@@ -119,3 +237,57 @@ def round_up_to_next_multiple(n: ArrayLike, base: ArrayLike) -> NDArray:
 
     out = base * np.ceil(n / base)
     return np.require(out, dtype=out_dtype)
+
+
+@contextmanager
+def scratch_directory(d: str | os.PathLike | None = None, /) -> Iterator[Path]:
+    """
+    Context manager that creates a (possibly temporary) filesystem directory.
+
+    If the input is a path-like object, a directory will be created at the
+    specified filesystem path if it did not already exist. The directory will
+    persist after leaving the context manager scope.
+
+    If the input is None, a temporary directory is created as though by
+    ``tempfile.TemporaryDirectory()``. Upon exiting the context manager scope, the
+    directory and its contents are removed from the filesystem.
+
+    Parameters
+    ----------
+    d : path-like or None, optional
+        Scratch directory path. If None, a temporary directory is created. Defaults to
+        None.
+
+    Yields
+    ------
+    d : pathlib.Path
+        Scratch directory path. If the input was None, the directory is removed
+        from the filesystem upon exiting the context manager scope.
+    """
+    if d is None:
+        try:
+            tmpdir = TemporaryDirectory()
+            yield Path(tmpdir.name)
+        finally:
+            tmpdir.cleanup()
+    else:
+        d = Path(d)
+        d.mkdir(parents=True, exist_ok=True)
+        yield d
+
+
+def unique_nonzero_integers(x: ArrayLike, /) -> set:
+    """
+    Find unique nonzero elements in the input array.
+
+    Parameters
+    ----------
+    x : array_like
+        An array of integers.
+
+    Returns
+    -------
+    s : set
+        The set of unique nonzero values.
+    """
+    return set(np.unique(x)) - {0}

--- a/test/test_label.py
+++ b/test/test_label.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import itertools
+
+import dask.array as da
+import numpy as np
+import numpy.testing as npt
+import pytest
+import scipy.ndimage
+from numpy.typing import NDArray
+
+import tophu
+from tophu._label import NO_OVERLAPPING_LABEL, find_max_overlapping_labels, relabel
+
+
+def random_binary_mask(
+    shape: tuple[int, ...],
+    *,
+    density: float,
+    seed: int | None = None,
+) -> NDArray[np.bool_]:
+    """
+    Create a random binary mask.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        The shape of the output array.
+    density : float
+        The approximate density of nonzero values in the mask. Must be between 0 and 1.
+    seed : int or None, optional
+        Seed for initializing pseudo-random number generator state. Must be nonnegative.
+        If None, then the generator will be initialized randomly. Defaults to None.
+
+    Returns
+    -------
+    mask : numpy.ndarray
+        A randomly generated binary mask.
+    """
+    if (density < 0.0) or (density > 1.0):
+        raise ValueError("density must be >= 0 and <= 1")
+
+    # Setup a pseudo-random number generator.
+    rng = np.random.default_rng(seed)
+
+    # Generate a random binary mask by uniformly sampling the interval [0, 1] and
+    # thresholding.
+    return rng.uniform(size=shape) < density
+
+
+def random_conncomp_labels(
+    shape: tuple[int, ...],
+    *,
+    density: float,
+    seed: int | None = None,
+) -> NDArray[np.integer]:
+    """
+    Create a random array of connected component labels.
+
+    Each connected component is assigned a unique positive integer label. Pixels not
+    belonging to any connected component are labeled 0.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        The shape of the output array.
+    density : float
+        The approximate density of nonzero values in the output array. Must be between 0
+        and 1.
+    seed : int or None, optional
+        Seed for initializing pseudo-random number generator state. Must be nonnegative.
+        If None, then the generator will be initialized randomly. Defaults to None.
+
+    Returns
+    -------
+    conncomp : numpy.ndarray
+        The output array of randomly generated connected component labels.
+    """
+    mask = random_binary_mask(shape, density=density, seed=seed)
+    conncomp, _ = scipy.ndimage.label(mask)
+    return conncomp
+
+
+class TestFindMaxOverlappingLabels:
+    def test_fully_overlapping(self):
+        # A connected components array with 3 rectangular-shaped components.
+        cc1 = np.zeros((128, 128), np.uint32)
+        cc1[10:20, 10:20] = 1
+        cc1[50:55, 5:25] = 2
+        cc1[80:100, 80:120] = 3
+
+        # Second connected components array is the same as the first
+        cc2 = cc1.copy()
+
+        label_mapping = find_max_overlapping_labels(cc1, cc2, min_overlap=1.0)
+
+        # The output dict should map each original CC label to itself.
+        assert label_mapping == {1: 1, 2: 2, 3: 3}
+
+    def test_multiple_overlapping_labels(self):
+        shape = (128, 128)
+        dtype = np.uint32
+
+        # Initial CC array just contains one big component.
+        cc1 = np.ones(shape, dtype)
+
+        # The second CC array contains 3 rectangular-shaped components with different
+        # sizes.
+        cc2 = np.zeros(shape, dtype)
+        cc2[10:20, 10:20] = 1
+        cc2[50:55, 5:25] = 2
+        cc2[80:100, 80:120] = 3
+
+        label_mapping = find_max_overlapping_labels(cc1, cc2, min_overlap=1e-6)
+
+        # Check that the mapped-to component label is the one with the most overlapping
+        # area (i.e. the largest component in the second array).
+        assert label_mapping == {1: 3}
+
+    def test_no_overlap(self):
+        shape = (128, 128)
+        dtype = np.uint32
+
+        # A connected components array with 3 rectangular-shaped components.
+        cc1 = np.zeros(shape, dtype)
+        cc1[10:20, 10:20] = 1
+        cc1[50:55, 5:25] = 2
+        cc1[80:100, 80:120] = 3
+
+        # Another connected components array with no components that overlap with the
+        # first array's components.
+        cc2 = np.zeros(shape, dtype)
+        cc2[10:20, 21:31] = 4
+        cc2[50:55, 26:50] = 5
+        cc2[60:79, 80:120] = 6
+
+        label_mapping = find_max_overlapping_labels(cc1, cc2, min_overlap=1e-6)
+
+        # Check that each initial label is mapped to `NO_OVERLAPPING_LABEL`.
+        expected = {
+            1: NO_OVERLAPPING_LABEL,
+            2: NO_OVERLAPPING_LABEL,
+            3: NO_OVERLAPPING_LABEL,
+        }
+        assert label_mapping == expected
+
+    def test_insufficient_overlap(self):
+        shape = (128, 128)
+        dtype = np.uint32
+
+        # Initial CC array just contains one big component.
+        cc1 = np.ones(shape, dtype)
+
+        # Second CC array contains one component whose intersection with the first
+        # component is 49% of its total area.
+        cc2 = np.zeros(shape, dtype)
+        cc2[:5] = 1
+        cc2[0, 0] = 0
+
+        # Require CCs to overlap by >= 50% to be considered overlapping.
+        label_mapping = find_max_overlapping_labels(cc1, cc2, min_overlap=0.5)
+
+        # Check that the initial label is mapped to `NO_OVERLAPPING_LABEL`.
+        assert label_mapping == {1: NO_OVERLAPPING_LABEL}
+
+    def test_overlap_ratio(self):
+        shape = (128, 128)
+        dtype = np.uint32
+
+        # Initial CC array contains one small rectangular-shaped component.
+        cc1 = np.zeros(shape, dtype)
+        cc1[50:60, 20:30] = 1
+
+        # Second CC array contains one much larger rectangular-shaped component.
+        # The intersection between the two components is 50% of the initial component's
+        # area, but a much smaller percentage of the second component's area.
+        cc2 = np.zeros(shape, dtype)
+        cc2[10:120, 25:100] = 2
+
+        # Require CCs to overlap by >= 50% to be considered overlapping.
+        label_mapping = find_max_overlapping_labels(cc1, cc2, min_overlap=0.5)
+
+        # Check that the components are sufficiently overlapping.
+        assert label_mapping == {1: 2}
+
+    def test_all_zeros(self):
+        shape = (128, 128)
+        dtype = np.uint32
+
+        # Initial CC array is all zeros.
+        cc1 = np.zeros(shape, dtype)
+
+        # The second CC array contains 3 rectangular-shaped components with different
+        # sizes.
+        cc2 = np.zeros(shape, dtype)
+        cc2[10:20, 10:20] = 1
+        cc2[50:55, 5:25] = 2
+        cc2[80:100, 80:120] = 3
+
+        label_mapping = find_max_overlapping_labels(cc1, cc2)
+
+        # Check that the label mapping is an empty dict.
+        assert label_mapping == {}
+
+    def test_shape_mismatch(self):
+        cc1 = random_conncomp_labels(shape=(100, 100), density=0.6)
+        cc2 = random_conncomp_labels(shape=(100, 101), density=0.6)
+
+        errmsg = (
+            r"^shape mismatch: input connected components arrays must have the same"
+            r" shape$"
+        )
+        with pytest.raises(ValueError, match=errmsg):
+            find_max_overlapping_labels(cc1, cc2)
+
+    def test_bad_min_overlap(self):
+        cc1 = random_conncomp_labels(shape=(128, 128), density=0.6)
+        cc2 = random_conncomp_labels(shape=(128, 128), density=0.6)
+
+        with pytest.raises(ValueError, match=r"^min overlap must be > 0"):
+            find_max_overlapping_labels(cc1, cc2, min_overlap=0.0)
+
+        with pytest.raises(ValueError, match=r"^min overlap must be <= 1"):
+            find_max_overlapping_labels(cc1, cc2, min_overlap=1.0 + 1e-6)
+
+
+def test_relabel():
+    # A connected components array with 3 rectangular-shaped components.
+    conncomp = np.zeros((128, 128), np.uint32)
+    conncomp[10:20, 10:20] = 1
+    conncomp[50:55, 5:25] = 2
+    conncomp[80:100, 80:120] = 3
+
+    # Make a copy of the input connected components array.
+    conncomp_orig = conncomp.copy()
+
+    # Define a mapping from input labels to output labels.
+    label_mapping = {1: 4, 2: 1, 3: 3}
+
+    # Relabel.
+    relabeled = relabel(conncomp, label_mapping)
+
+    # Check the output labels for each CC.
+    for label in [1, 2, 3]:
+        mask1 = conncomp == label
+        mask2 = relabeled == label_mapping[label]
+        npt.assert_array_equal(mask1, mask2)
+
+    # Check that the input array was not modified.
+    npt.assert_array_equal(conncomp, conncomp_orig)
+
+
+def iterchunks(arr: da.Array) -> np.ndarray:
+    """Iterate over blocks of a Dask array."""
+    for ix in itertools.product(*map(range, arr.blocks.shape)):
+        yield np.asanyarray(arr.blocks[ix])
+
+
+class TestRelabelHiresConncomps:
+    def test_deduplicate_labels(self):
+        shape = (200, 200)
+        chunksize = (100, 100)
+        dtype = np.uint32
+
+        # Each tile contains a single connected component, all with the same label.
+        tiled_conncomp = da.ones(shape=shape, dtype=dtype, chunks=chunksize)
+
+        # The coarse CC array contains four different components, one filling each
+        # quadrant of the array.
+        coarse_conncomp_ = np.zeros(shape=shape, dtype=dtype)
+        coarse_conncomp_[:100, :100] = 1
+        coarse_conncomp_[:100, 100:] = 2
+        coarse_conncomp_[100:, :100] = 3
+        coarse_conncomp_[100:, 100:] = 4
+        coarse_conncomp = da.from_array(coarse_conncomp_, chunks=chunksize)
+
+        # Relabel.
+        relabeled = tophu.relabel_hires_conncomps(tiled_conncomp, coarse_conncomp)
+
+        # After relabeling, there should be no common labels between different tiles.
+        # Get the set of unique labels within each tile and check that each pair of sets
+        # is disjoint (has no common elements).
+        unique_block_labels = [set(np.unique(block)) for block in iterchunks(relabeled)]
+        for set1, set2 in itertools.combinations(unique_block_labels, r=2):
+            assert set1.isdisjoint(set2)
+
+    def test_no_coarse_conncomps(self):
+        # Each tile contains a single connected component, all with the same label.
+        tiled_conncomp = da.ones(shape=(200, 200), dtype=np.uint32, chunks=(100, 100))
+
+        # The coarse connected components array contains no components.
+        coarse_conncomp = da.zeros_like(tiled_conncomp)
+
+        # Relabel.
+        relabeled = tophu.relabel_hires_conncomps(tiled_conncomp, coarse_conncomp)
+
+        # After relabeling, there should be no common labels between different tiles.
+        # Get the set of unique labels within each tile and check that each pair of sets
+        # is disjoint (has no common elements).
+        unique_block_labels = [set(np.unique(block)) for block in iterchunks(relabeled)]
+        for set1, set2 in itertools.combinations(unique_block_labels, r=2):
+            assert set1.isdisjoint(set2)
+
+    def test_merge_labels(self):
+        # Create random CCs across all tiles, each with a unique label.
+        shape = (128, 128)
+        tiled_conncomp_ = random_conncomp_labels(shape, density=0.6, seed=1234)
+        tiled_conncomp = da.from_array(tiled_conncomp_, chunks=(65, 65))
+
+        # The coarse CC array is filled by a single component.
+        coarse_conncomp = da.ones_like(tiled_conncomp)
+
+        # Relabel.
+        relabeled = tophu.relabel_hires_conncomps(tiled_conncomp, coarse_conncomp)
+
+        # Each CC should have the same label after relabeling.
+        mask = tiled_conncomp != 0
+        assert da.all(relabeled[mask] == 1)
+        assert da.all(relabeled[~mask] == 0)
+
+    def test_output_natural_numbers(self):
+        # Generate an initial set of CCs but add 100 to each label.
+        shape = (128, 128)
+        tiled_conncomp_ = random_conncomp_labels(shape, density=0.6, seed=1234)
+        tiled_conncomp_[tiled_conncomp_ != 0] += 100
+        tiled_conncomp = da.from_array(tiled_conncomp_, chunks=(64, 64))
+
+        # Coarse CCs are identical to tiled CCs.
+        coarse_conncomp = tiled_conncomp.copy()
+
+        # Relabel.
+        relabeled = tophu.relabel_hires_conncomps(tiled_conncomp, coarse_conncomp)
+        relabeled = relabeled.compute()
+
+        # The new connected components should be labeled [1, 2, ..., N], where N is the
+        # total number of components, regardless of the initial labels.
+        nlabels = len(tophu.unique_nonzero_integers(relabeled))
+        unique_labels = np.unique(relabeled)
+        npt.assert_array_equal(unique_labels, np.arange(nlabels + 1))
+
+    def test_shape_mismatch(self):
+        tiled_conncomp_ = random_conncomp_labels(shape=(100, 100), density=0.6)
+        coarse_conncomp_ = random_conncomp_labels(shape=(100, 101), density=0.6)
+
+        tiled_conncomp = da.from_array(tiled_conncomp_, chunks=(128, 128))
+        coarse_conncomp = da.from_array(coarse_conncomp_, chunks=(128, 128))
+
+        errmsg = (
+            r"^shape mismatch: the high-res and low-res connected components arrays"
+            r" must have the same shape$"
+        )
+        with pytest.raises(ValueError, match=errmsg):
+            tophu.relabel_hires_conncomps(tiled_conncomp, coarse_conncomp)
+
+    def test_chunksize_mismatch(self):
+        tiled_conncomp_ = random_conncomp_labels(shape=(100, 100), density=0.6)
+        coarse_conncomp_ = random_conncomp_labels(shape=(100, 100), density=0.6)
+
+        tiled_conncomp = da.from_array(tiled_conncomp_, chunks=(50, 50))
+        coarse_conncomp = da.from_array(coarse_conncomp_, chunks=(50, 51))
+
+        errmsg = (
+            r"^the high-res and low-res connected components arrays must have the same"
+            r" chunk sizes$"
+        )
+        with pytest.raises(ValueError, match=errmsg):
+            tophu.relabel_hires_conncomps(tiled_conncomp, coarse_conncomp)

--- a/test/test_unwrap.py
+++ b/test/test_unwrap.py
@@ -1,10 +1,7 @@
-import warnings
-
 import numpy as np
 import pytest
 from isce3.unwrap import snaphu
 from numpy.typing import ArrayLike, NDArray
-from scipy.stats import mode
 
 import tophu
 
@@ -223,9 +220,7 @@ class TestICUUnwrap:
         # label matches the modal (most common) label from that region. It also checks
         # that the modal label is nonzero.
         for mask in [mask1, mask2]:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=FutureWarning)
-                modal_label, _ = mode(conncomp[mask], axis=None)
+            modal_label, _ = tophu.mode(conncomp[mask])
             assert frac_nonzero(conncomp[mask] == modal_label) > 0.95
             assert modal_label != 0
 
@@ -310,9 +305,7 @@ class TestPhassUnwrap:
         # label matches the modal (most common) label from that region. It also checks
         # that the modal label is nonzero.
         for mask in [mask1, mask2]:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=FutureWarning)
-                modal_label, _ = mode(conncomp[mask], axis=None)
+            modal_label, _ = tophu.mode(conncomp[mask])
             assert frac_nonzero(conncomp[mask] == modal_label) > 0.95
             assert modal_label != 0
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -60,6 +60,19 @@ class TestCeilDivide:
         np.testing.assert_array_equal(result, expected)
 
 
+class TestGetAllUniqueValues:
+    def test1(self):
+        d1 = {"a": 0, "b": 1, "c": 2}
+        d3 = {"d": 0, "e": 1, "f": 2}
+        d2 = {"a": 3, "b": 4, "c": 5}
+        d4 = {}
+        unique_vals = tophu.get_all_unique_values([d1, d2, d3, d4])
+        assert unique_vals == {0, 1, 2, 3, 4, 5}
+
+    def test_empty(self):
+        assert tophu.get_all_unique_values([]) == set()
+
+
 class TestGetLock:
     def test_no_scheduler(self):
         assert isinstance(tophu.get_lock(), (ThreadingLock, SerializableLock))
@@ -102,6 +115,68 @@ class TestGetLock:
             assert isinstance(tophu.get_lock(), Lock)
 
 
+class TestGetTileDims:
+    @pytest.mark.parametrize(
+        "shape,ntiles,tiledims",
+        [
+            ((99, 100), (3, 3), (33, 34)),
+            ((60, 60, 60), (3, 4, 5), (20, 15, 12)),
+            ((128, 129), (1, 1), (128, 129)),
+            ((100, 100), (101, 1_000_000), (1, 1)),
+        ],
+    )
+    def test_simple(
+        self,
+        shape: tuple[int, ...],
+        ntiles: tuple[int, ...],
+        tiledims: tuple[int, ...],
+    ):
+        assert tophu.get_tile_dims(shape, ntiles) == tiledims
+
+    @pytest.mark.parametrize(
+        "shape,ntiles,snap_to,tiledims",
+        [
+            ((30, 40, 50), (3, 4, 5), (5, 6, 7), (10, 12, 14)),
+            ((99, 100), (3, 3), (5, 6), (35, 36)),
+            ((60, 60, 60), (3, 4, 5), (3, 3, 3), (21, 15, 12)),
+            ((128, 129), (1, 1), (200, 200), (128, 129)),
+        ],
+    )
+    def test_snap_to(
+        self,
+        shape: tuple[int, ...],
+        ntiles: tuple[int, ...],
+        snap_to: tuple[int, ...],
+        tiledims: tuple[int, ...],
+    ):
+        assert tophu.get_tile_dims(shape, ntiles, snap_to) == tiledims
+
+    def test_size_mismatch(self):
+        errmsg = r"^size mismatch: shape and ntiles must have same length$"
+        with pytest.raises(ValueError, match=errmsg):
+            tophu.get_tile_dims(shape=(100, 200, 300), ntiles=(1, 2))
+
+        errmsg = r"^size mismatch: shape and snap_to must have same length$"
+        with pytest.raises(ValueError, match=errmsg):
+            tophu.get_tile_dims(shape=(100, 200, 300), ntiles=(1, 2, 3), snap_to=(1, 2))
+
+    def test_bad_shape(self):
+        with pytest.raises(ValueError, match=r"array axis lengths must be >= 1"):
+            tophu.get_tile_dims(shape=(100, 0, 100), ntiles=(3, 3, 3))
+
+    def test_bad_ntiles(self):
+        with pytest.raises(ValueError, match=r"number of tiles must be >= 1"):
+            tophu.get_tile_dims(shape=(100, 100, 100), ntiles=(3, 0, 3))
+
+    def test_bad_snap_to(self):
+        with pytest.raises(ValueError, match=r"snap_to lengths must be >= 1"):
+            tophu.get_tile_dims(
+                shape=(100, 100, 100),
+                ntiles=(3, 3, 3),
+                snap_to=(5, 0, 5),
+            )
+
+
 def test_iseven():
     assert tophu.iseven(2)
     assert tophu.iseven(-2)
@@ -137,8 +212,59 @@ class TestMapBlocks:
         assert da.all(rem == a % b)
 
 
+class TestMergeSets:
+    def test1(self):
+        assert tophu.merge_sets([{1, 2}, {3, 4}, {5, 6}]) == {1, 2, 3, 4, 5, 6}
+
+    def test2(self):
+        assert tophu.merge_sets([{1, 2}, {2, 3}, {3, 4}]) == {1, 2, 3, 4}
+
+    def test_empty(self):
+        assert tophu.merge_sets([]) == set()
+
+
+class TestMode:
+    def test_simple(self):
+        arr = [0, 0, 1, 1, 1, 2, 2, 3]
+        mode, count = tophu.mode(arr)
+        assert mode == 1
+        assert count == 3
+
+    def test_multiple_modes(self):
+        arr = [0, 1, 1, 1, 2, 2, 2, 3]
+        mode, count = tophu.mode(arr)
+        assert mode in (1, 2)
+        assert count == 3
+
+    def test_empty(self):
+        mode, count = tophu.mode([])
+        assert np.isnan(mode)
+        assert count == 0
+
+    def test_scalar(self):
+        mode, count = tophu.mode(100.0)
+        assert mode == 100.0
+        assert count == 1
+
+
 def test_round_up_to_next_multiple():
     assert tophu.round_up_to_next_multiple(5, 10) == 10
     assert tophu.round_up_to_next_multiple(10, 10) == 10
     assert tophu.round_up_to_next_multiple(11, 10) == 20
     assert tophu.round_up_to_next_multiple(-19, 10) == -10
+
+
+def test_scratch_directory():
+    with tophu.scratch_directory() as d1:
+        assert d1.is_dir()
+        with tophu.scratch_directory(d1) as d2:
+            assert d2 == d1
+            assert d2.is_dir()
+        assert d2.is_dir()
+    assert not d1.is_dir()
+
+
+def test_unique_nonzero_integers():
+    arr = [0, 0, 0, 1, 1, 2, 2, 2, 3]
+    out = tophu.unique_nonzero_integers(arr)
+    assert out == {1, 2, 3}


### PR DESCRIPTION
This PR updates the `multiscale_unwrap()` function to perform a post-processing step that relabels the connected components resulting from tiled unwrapping using the coarse-unwrapped connected components.

When a large interferogram is unwrapped using a tiled unwrapping approach, each tile is independently assigned connected component labels. This can cause some issues for interpreting the resulting connected components:

* Labels may not be unique across tiles. Two different components in two different tiles may be assigned the same integer label.
* If a contiguous region of reliable unwrapped phase spans multiple tiles, it may be assigned different labels in each of the different tiles.

The relabeling step attempts to address these issues by assigning each connected component a new label based on the low-resolution (i.e. coarse-unwrapped) connected component that it most overlapped with. Two or more high-res connected components that overlapped with the same low-res connected component will be assigned the same final label. High-res connected components that overlapped with different low-res connected components will be assigned distinct labels. Each high-res connected component that didn't overlap with any low-res component will be assigned a new unique label.

It's possible for the user to specify a minimum overlap fraction via the `min_conncomp_overlap` parameter. If the intersection between a high-res and low-res component (as a fraction of the area of the high-res component) is below this threshold, then the two won't be considered overlapping for purposes of relabeling.

The final set of connected components are assigned sequential positive integer labels [1, 2, ..., N], where N is the total number of unique components.

Implementing the relabeling step required some refactoring of the implementation of the `multiscale_unwrap()` function. The relabeling process needs to see the full set of connected component labels from all tiles, which requires the Dask task graph to be computed for each tile prior to relabeling. Later on, when we store the final unwrapped phase and connected component labels in their respective output datasets, the task graph would need to be re-computed in order to retrieve the unwrapped phase from each tile. So each tile would get unwrapped twice(!!) -- once during relabeling and once more during the final `dask.array.store()` step.

I've avoided this by writing the intermediate connected component labels arrays to temporary binary files prior to relabeling. I don't expect this to have much impact on runtime, since much of the latency of writing to disk should be hidden by parallel processing of different tiles, but it does make the code much messier. I haven't been able to think of a better approach so far, though.