### PR TITLE
Revert codecov/codecov-action back to v3

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -52,4 +52,4 @@ jobs:
           micromamba install -f test/requirements.txt -c conda-forge
           pytest --cov-report=xml
       - name: Coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
Revert #32

This update caused CI to break after merging, with error message:

```
Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`
```

The [codecov-action v4 releases](https://github.com/codecov/codecov-action/releases) appear to be unstable pre-releases currently. Maybe one of these was temporarily marked as a stable release by accident, triggering the dependabot update?