### PR TITLE
allow the passing of options to `RasterBand`

### DIFF
--- a/src/tophu/_io.py
+++ b/src/tophu/_io.py
@@ -566,7 +566,7 @@ class RasterBand(DatasetReader, DatasetWriter):
             crs=crs,
             transform=transform,
             dtype=dtype,
-            options=options,
+            **options,
         ) as dataset:
             # Band index must not be None if the dataset contains more than one band.
             # If a band index was supplied, check that it's within the range of valid

--- a/src/tophu/_io.py
+++ b/src/tophu/_io.py
@@ -5,7 +5,7 @@ import os
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol, overload, runtime_checkable
+from typing import Any, Protocol, overload, runtime_checkable
 
 import h5py
 import numpy as np
@@ -480,6 +480,7 @@ class RasterBand(DatasetReader, DatasetWriter):
         driver: str | None = None,
         crs: str | dict | rasterio.crs.CRS | None = None,
         transform: rasterio.transform.Affine | None = None,
+        **options: dict[str, Any],
     ):  # noqa: D418
         """
         Construct a new `RasterBand` object.
@@ -515,6 +516,7 @@ class RasterBand(DatasetReader, DatasetWriter):
         driver=None,
         crs=None,
         transform=None,
+        **options,
     ):  # noqa: D107
         filepath = Path(filepath)
 
@@ -564,6 +566,7 @@ class RasterBand(DatasetReader, DatasetWriter):
             crs=crs,
             transform=transform,
             dtype=dtype,
+            options=options,
         ) as dataset:
             # Band index must not be None if the dataset contains more than one band.
             # If a band index was supplied, check that it's within the range of valid

--- a/src/tophu/_multiscale.py
+++ b/src/tophu/_multiscale.py
@@ -79,7 +79,7 @@ def lowpass_filter_and_multilook(
     def get_filter_coeffs(n: int) -> NDArray:
         # If `n` is 1, then the subsequent multilooking step will be a no-op, so there's
         # no need to apply a low-pass filter. In that case, we choose the filter
-        # coefficents to have a frequency response of unity.
+        # coefficients to have a frequency response of unity.
         if n == 1:
             return 1.0
 


### PR DESCRIPTION
These get passed to `rasterio.open(...)`

See https://github.com/rasterio/rasterio/blob/5e001a08beb747fef0b60b5ccdbf2e5a08da7e05/docs/topics/image_options.rst#creation-options, or the driver specific options on the GDAL documentation (e.g. https://gdal.org/drivers/raster/gtiff.html)


Example usage:

In `dolphin`, I've got [default creation options for the GTiff and ENVI drivers](https://github.com/isce-framework/dolphin/blob/9e1b729e56883bf7bb8b0ee3920e1225ae6d4a6d/src/dolphin/io.py#L39-L45). These would get converted to rasterio-compatible ones with something like 
```python
gtiff_options = dict(opt.lower().split("=") for opt in io.DEFAULT_TIFF_OPTIONS)`
#  {'compress': 'deflate', 'zlevel': '4', 'tiled': 'yes', 'blockxsize': '128', 'blockysize': '128'}
```

then my `RasterBand` creation could be 
```python
unw_rb = RasterBand(
    unw_filename,
    height=height,
    width=width,
    dtype=np.float32,
    crs=crs,
    transform=transform,
    **gtiff_options,
)
```
