### PR TITLE
Add usage example to docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,5 +9,6 @@ interferometric synthetic aperture radar (InSAR).
    :hidden:
 
    installation
+   usage
    reference
    changelog

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -4,44 +4,44 @@ Usage
 Basic usage with raster files
 =============================
 
-
-
 .. code-block:: python
 
     from tophu import RasterBand, SnaphuUnwrap, multiscale_unwrap
     import rasterio as rio
-    # create `RasterBand`s from the input interferogram and coherence
+
+    # Create `RasterBand`s from the input interferogram and coherence.
     igram = RasterBand(ifg_filename)
     coherence = RasterBand(corr_filename)
-    # Create the output raster bands
-    # Start by copying the input geographic metadata
+
+    # Create the output raster bands.
+    # Start by copying the input geographic metadata.
     with rio.open(ifg_filename) as src:
         profile = src.profile
-    # The unwrapped phase will be float32
+
+    # The unwrapped phase will be float32.
     profile["dtype"] = np.float32
     profile["driver"] = "GTiff"
     unw = RasterBand("unwrapped_phase.unw.tif", **profile)
 
-    # Create the connected component labels raster
+    # Create the connected component labels raster.
     profile["dtype"] = np.uint16
     conncomp = RasterBand("connected_components.tif", **profile)
 
     # Choose which unwrapper we will use.
-    # Here we pick Snaphu
+    # Here we pick SNAPHU.
     unwrap_callback = SnaphuUnwrap(
         cost="smooth",
         init_method="mst",
     )
 
-    # Set the number of looks used to form the coherence
+    # Set the number of looks used to form the coherence.
     nlooks = 40
 
-    # Choose the tiling scheme and the downsample factor
-    # for the coarse unwrap
+    # Choose the tiling scheme and the downsample factor for the coarse unwrap.
     ntiles = (2, 2)
     downsample_factor = (3, 3)
 
-    # Run the multiscale unwrapping function
+    # Run the multiscale unwrapping function.
     multiscale_unwrap(
         unw,
         conncomp,

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -48,7 +48,7 @@ Basic usage with raster files
         igram,
         coherence,
         nlooks=nlooks,
-        unwrap=unwrap_callback,
+        unwrap_func=unwrap_callback,
         downsample_factor=downsample_factor,
         ntiles=ntiles,
     )

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,0 +1,54 @@
+Usage
+#####
+
+Basic usage with raster files
+=============================
+
+
+
+.. code-block:: python
+
+    from tophu import RasterBand, SnaphuUnwrap, multiscale_unwrap
+    import rasterio as rio
+    # create `RasterBand`s from the input interferogram and coherence
+    igram = RasterBand(ifg_filename)
+    coherence = RasterBand(corr_filename)
+    # Create the output raster bands
+    # Start by copying the input geographic metadata
+    with rio.open(ifg_filename) as src:
+        profile = src.profile
+    # The unwrapped phase will be float32
+    profile["dtype"] = np.float32
+    profile["driver"] = "GTiff"
+    unw = RasterBand("unwrapped_phase.unw.tif", **profile)
+
+    # Create the connected component labels raster
+    profile["dtype"] = np.uint16
+    conncomp = RasterBand("connected_components.tif", **profile)
+
+    # Choose which unwrapper we will use.
+    # Here we pick Snaphu
+    unwrap_callback = SnaphuUnwrap(
+        cost="smooth",
+        init_method="mst",
+    )
+
+    # Set the number of looks used to form the coherence
+    nlooks = 40
+
+    # Choose the tiling scheme and the downsample factor
+    # for the coarse unwrap
+    ntiles = (2, 2)
+    downsample_factor = (3, 3)
+
+    # Run the multiscale unwrapping function
+    multiscale_unwrap(
+        unw,
+        conncomp,
+        igram,
+        coherence,
+        nlooks=nlooks,
+        unwrap=unwrap_callback,
+        downsample_factor=downsample_factor,
+        ntiles=ntiles,
+    )


### PR DESCRIPTION
WIP, I need to check how to locally build sphinx.

I'm also open to "that is not at all how I'd introduce the usage" if you have different opinions.




But when trying to build on linux, I got the error

```
$ make html
Extension error (sphinx.ext.autosummary):
Handler <function process_generate_options at 0x7fbadc75b4c0> for event 'builder-inited' threw an exception (exception: no module named tophu.TiledPartition)
make: *** [html] Error 2
```


and on mac I got the classic


```python-traceback
Traceback (most recent call last):
  File "/Users/staniewi/miniconda3/envs/mapping/lib/python3.10/site-packages/sphinx/config.py", line 347, in eval_config_file
    exec(code, namespace)
  File "/Users/staniewi/repos/tophu/docs/source/conf.py", line 3, in <module>
    import tophu
  File "/Users/staniewi/repos/tophu/src/tophu/__init__.py", line 5, in <module>
    from ._multiscale import *
  File "/Users/staniewi/repos/tophu/src/tophu/_multiscale.py", line 17, in <module>
    from ._unwrap import UnwrapCallback
  File "/Users/staniewi/repos/tophu/src/tophu/_unwrap.py", line 10, in <module>
    import isce3
  File "/Users/staniewi/repos/isce3/install/packages/isce3/__init__.py", line 2, in <module>
    from .ext import extisce3
  File "/Users/staniewi/repos/isce3/install/packages/isce3/ext/__init__.py", line 3, in <module>
    from . import isce3 as extisce3
ImportError: dlopen(/Users/staniewi/repos/isce3/install/packages/isce3/ext/isce3.cpython-310-darwin.so, 0x0002): Library not loaded: @rpath/libisce3.0.dylib
  Referenced from: <9D92F2C0-7221-38F1-86A3-D88793E67774> /Users/staniewi/repos/isce3/install/packages/isce3/ext/isce3.cpython-310-darwin.so
  Reason: tried: '/Users/staniewi/miniconda3/envs/mapping/lib/libisce3.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/staniewi/miniconda3/envs/mapping/lib/libisce3.0.dylib' (no such file), '/Users/staniewi/miniconda3/envs/mapping/lib/libisce3.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/staniewi/miniconda3/envs/mapping/lib/libisce3.0.dylib' (no such file), '/Users/staniewi/miniconda3/envs/mapping/bin/../lib/libisce3.0.dylib' (no such file), '/Users/staniewi/miniconda3/envs/mapping/bin/../lib/libisce3.0.dylib' (no such file), '/usr/local/lib/libisce3.0.dylib' (no such file), '/usr/lib/libisce3.0.dylib' (no such file, not in dyld cache)
```
(despite the fact that `import isce3` works fine in a normal interpreter)