### PR TITLE
Bump RtD mamba version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-22.9"
   commands:
     - mamba install --file requirements.txt --channel conda-forge
     - mamba install --file docs/requirements.txt --channel conda-forge


### PR DESCRIPTION
Testing to see if this fixes the issue with ReadTheDocs builds, which seem to have been failing for a week or so.

I'm seeing the following error message on https://readthedocs.org/projects/tophu/builds during the `mamba install` step

```
Traceback (most recent call last):
  File "/home/docs/.asdf/installs/python/mambaforge-4.10.3-10/bin/mamba", line 7, in <module>
    from mamba.mamba import main
  File "/home/docs/.asdf/installs/python/mambaforge-4.10.3-10/lib/python3.11/site-packages/mamba/mamba.py", line 49, in <module>
    import libmambapy as api
  File "/home/docs/.asdf/installs/python/mambaforge-4.10.3-10/lib/python3.11/site-packages/libmambapy/__init__.py", line 7, in <module>
    raise e
  File "/home/docs/.asdf/installs/python/mambaforge-4.10.3-10/lib/python3.11/site-packages/libmambapy/__init__.py", line 4, in <module>
    from libmambapy.bindings import *  # noqa: F401,F403
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: /home/docs/.asdf/installs/python/mambaforge-4.10.3-10/lib/python3.11/site-packages/libmambapy/../../../libmamba.so.2: undefined symbol: solver_ruleinfo2str, version SOLV_1.0
```